### PR TITLE
Fix Pangolin build failure with GCC 13 by adding missing <cstdint> includes

### DIFF
--- a/thirdparty/pangolin/components/pango_image/src/image_io_bmp.cpp
+++ b/thirdparty/pangolin/components/pango_image/src/image_io_bmp.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <fstream>
 #include <pangolin/image/typed_image.h>
 

--- a/thirdparty/pangolin/components/pango_image/src/image_io_jpg.cpp
+++ b/thirdparty/pangolin/components/pango_image/src/image_io_jpg.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cstdint>
 #include <fstream>
 
 

--- a/thirdparty/pangolin/components/pango_packetstream/include/pangolin/log/packetstream_tags.h
+++ b/thirdparty/pangolin/components/pango_packetstream/include/pangolin/log/packetstream_tags.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace pangolin {


### PR DESCRIPTION
GCC 13 no longer implicitly includes `<cstdint>` through other standard headers. Add explicit `#include <cstdint>` to the Pangolin source files that use fixed-width integer types (e.g. `uint8_t`).
